### PR TITLE
Feat: return jwt token in user-related features

### DIFF
--- a/src/main/java/com/liviz/v2/config/JwtRequestFilter.java
+++ b/src/main/java/com/liviz/v2/config/JwtRequestFilter.java
@@ -29,6 +29,12 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws ServletException, IOException {
 
+        String requestPath = request.getServletPath();
+        if (requestPath.equals("/auth/create_anonymous")) {
+            chain.doFilter(request, response);
+            return;
+        }
+
         final String requestTokenHeader = request.getHeader("Authorization");
 
         String username = null;

--- a/src/main/java/com/liviz/v2/controller/ProjectController.java
+++ b/src/main/java/com/liviz/v2/controller/ProjectController.java
@@ -7,6 +7,7 @@ import com.liviz.v2.dto.ProjectPutDataSourceDto;
 import com.liviz.v2.dto.ProjectPutDisplaySchemaDto;
 import com.liviz.v2.model.Project;
 import com.liviz.v2.model.User;
+import com.liviz.v2.service.ProjectService;
 import com.liviz.v2.serviceImpl.ProjectServiceImpl;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -22,7 +23,7 @@ import java.util.List;
 @RequestMapping("/projects")
 public class ProjectController {
     @Autowired
-    ProjectServiceImpl projectService;
+    ProjectService projectService;
 
     @Autowired
     JwtTokenUtil jwtTokenUtil;

--- a/src/main/java/com/liviz/v2/controller/ShareConfigController.java
+++ b/src/main/java/com/liviz/v2/controller/ShareConfigController.java
@@ -5,6 +5,7 @@ import com.liviz.v2.dto.DisplaySchemaChangePasswordDto;
 import com.liviz.v2.dto.ShareConfigDto;
 import com.liviz.v2.model.ShareConfig;
 import com.liviz.v2.model.User;
+import com.liviz.v2.service.ShareConfigService;
 import com.liviz.v2.serviceImpl.ShareConfigServiceImpl;
 import org.apache.commons.logging.Log;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +20,7 @@ import java.util.List;
 @RequestMapping("/share_configs")
 public class ShareConfigController {
     @Autowired
-    ShareConfigServiceImpl shareConfigService;
+    ShareConfigService shareConfigService;
 
     @Autowired
     JwtTokenUtil jwtTokenUtil;

--- a/src/main/java/com/liviz/v2/dto/AuthResponseDto.java
+++ b/src/main/java/com/liviz/v2/dto/AuthResponseDto.java
@@ -1,0 +1,14 @@
+package com.liviz.v2.dto;
+
+import com.liviz.v2.model.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AuthResponseDto {
+    private JwtResponse token;
+    private User user;
+}

--- a/src/main/java/com/liviz/v2/service/UserService.java
+++ b/src/main/java/com/liviz/v2/service/UserService.java
@@ -1,5 +1,6 @@
 package com.liviz.v2.service;
 
+import com.liviz.v2.dto.AuthResponseDto;
 import com.liviz.v2.dto.AuthSignUpDto;
 import com.liviz.v2.dto.ChangePasswordDto;
 import com.liviz.v2.dto.ChangeUsernameDto;
@@ -14,11 +15,11 @@ public interface UserService {
 
     Optional<User> findByUsername(String username);
 
-    User changePassword(User jwtUser, String userId, ChangePasswordDto changePasswordDto);
+    AuthResponseDto changePassword(User jwtUser, String userId, ChangePasswordDto changePasswordDto);
 
-    User changeUsername(User jwtUser, String userId, ChangeUsernameDto changeUsernameDto);
+    AuthResponseDto changeUsername(User jwtUser, String userId, ChangeUsernameDto changeUsernameDto);
 
     User resetUser(User jwtUser, String userId);
 
-    User authenticateAnonymousUser(User jwtUser, AuthSignUpDto authSignUpDto);
+    AuthResponseDto authenticateAnonymousUser(User jwtUser, AuthSignUpDto authSignUpDto);
 }

--- a/src/main/java/com/liviz/v2/serviceImpl/AuthServiceImpl.java
+++ b/src/main/java/com/liviz/v2/serviceImpl/AuthServiceImpl.java
@@ -90,9 +90,9 @@ public class AuthServiceImpl implements AuthService {
         try {
             authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, password));
         } catch (DisabledException e) {
-            throw new Exception("USER_DISABLED", e);
+            throw new UnauthenticatedException("USER_DISABLED");
         } catch (BadCredentialsException e) {
-            throw new Exception("INVALID_CREDENTIALS", e);
+            throw new UnauthenticatedException("INVALID_CREDENTIALS");
         }
     }
 

--- a/src/main/java/com/liviz/v2/utils/JwtResponseBuilder.java
+++ b/src/main/java/com/liviz/v2/utils/JwtResponseBuilder.java
@@ -1,0 +1,31 @@
+package com.liviz.v2.utils;
+
+import com.liviz.v2.config.JwtTokenUtil;
+import com.liviz.v2.dto.AuthResponseDto;
+import com.liviz.v2.dto.JwtResponse;
+import com.liviz.v2.model.User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+@Component
+public class JwtResponseBuilder {
+    public AuthResponseDto build(User user, JwtTokenUtil jwtTokenUtil) {
+        // get userDetails
+        final UserDetails userDetails = new org.springframework.security.core.userdetails.User(user.getUsername(), user.getPassword(),
+                new ArrayList<>());
+
+        // generate token
+        final String token = jwtTokenUtil.generateToken(userDetails);
+
+        // return token and user
+        AuthResponseDto authResponseDto = new AuthResponseDto();
+        authResponseDto.setUser(user);
+        authResponseDto.setToken(new JwtResponse(token));
+        return authResponseDto;
+    }
+}


### PR DESCRIPTION
fix:

1. Ignore Authorization header, no matter provided or not, for all public (no auth required) endpoints.

feat:

1. Return { ”user”: {…}, “token”: { “jwtToken”: “xxx” } } for
    -  `/auth/signup`
    -  `/users/{id}/username`